### PR TITLE
Fix "Using the option --errorFormat is deprecated, use --error-format"

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@ from SublimeLinter.lint import Linter
 
 
 class PhpStan(Linter):
-    cmd = 'phpstan', 'analyse', '--errorFormat=raw', '--no-progress', '${args}', '${file}'
+    cmd = 'phpstan', 'analyse', '--error-format=raw', '--no-progress', '${args}', '${file}'
     regex = r'^.*:(?P<line>[0-9]+):(?P<message>.+)'
     default_type = 'error'
     multiline = False


### PR DESCRIPTION
In new version of phpstan they change errorFormat to error-format