### PR TITLE
Fix linter, make it backwords compatibility

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@ from SublimeLinter.lint import Linter
 
 
 class PhpStan(Linter):
-    cmd = 'phpstan', 'analyse', '--errorFormat=raw', '--no-progress', '${args}', '${file}'
+    cmd = 'phpstan', 'analyse', '--error-format=raw', '--no-progress', '${args}', '${file}'
     regex = r'^.*:(?P<line>[0-9]+):(?P<message>.+)'
     default_type = 'error'
     multiline = False

--- a/linter.py
+++ b/linter.py
@@ -2,8 +2,8 @@ from SublimeLinter.lint import Linter
 
 
 class PhpStan(Linter):
-    cmd = 'phpstan', 'analyse', '--error-format=raw', '--no-progress', '${args}', '${file}'
-    regex = r'^.*:(?P<line>[0-9]+):(?P<message>.+)'
+    cmd = 'phpstan', 'analyse', '--errorFormat=raw', '--no-progress', '${args}', '${file}'
+    regex = r'^(?!Note: ).*:(?P<line>[0-9]+):(?P<message>.+)'
     default_type = 'error'
     multiline = False
     tempfile_suffix = '-'


### PR DESCRIPTION
Its related to #3
I use the same flag, but remove this extra "Note: ..." that phpstan adds, so plugin works now in both versions (older and new)