### PR TITLE
only use composer's autoloader by default

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,13 +2,20 @@ from SublimeLinter.lint import Linter
 
 
 class PhpStan(Linter):
-    cmd = 'phpstan', 'analyse', '--errorFormat=raw', '--no-progress', '${args}', '${file}'
-    regex = r'^(?!Note: ).*:(?P<line>[0-9]+):(?P<message>.+)'
-    default_type = 'error'
+    cmd = (
+        "phpstan",
+        "analyse",
+        "--errorFormat=raw",
+        "--no-progress",
+        "${args}",
+        "${file}",
+    )
+    regex = r"^(?!Note: ).*:(?P<line>[0-9]+):(?P<message>.+)"
+    default_type = "error"
     multiline = False
-    tempfile_suffix = '-'
+    tempfile_suffix = "-"
     defaults = {
-        'selector': 'source.php',
-        '--autoload-file': '${file}',
-        '--level': 'max',
+        "selector": "source.php",
+        "--autoload-file": "${file}",
+        "--level": "max",
     }

--- a/linter.py
+++ b/linter.py
@@ -5,7 +5,7 @@ class PhpStan(Linter):
     cmd = (
         "phpstan",
         "analyse",
-        "--errorFormat=raw",
+        "--error-format=raw",
         "--no-progress",
         "${args}",
         "${file}",

--- a/linter.py
+++ b/linter.py
@@ -1,21 +1,44 @@
+from os import path
+from shlex import quote
+
 from SublimeLinter.lint import Linter
 
 
 class PhpStan(Linter):
-    cmd = (
-        "phpstan",
-        "analyse",
-        "--error-format=raw",
-        "--no-progress",
-        "${args}",
-        "${file}",
-    )
     regex = r"^(?!Note: ).*:(?P<line>[0-9]+):(?P<message>.+)"
     default_type = "error"
     multiline = False
     tempfile_suffix = "-"
     defaults = {
         "selector": "source.php",
-        "--autoload-file": "${file}",
+        "use_composer_autoload": True,
         "--level": "max",
     }
+
+    def cmd(self):
+        settings = self.get_view_settings()
+
+        cmd = ["phpstan", "analyse"]
+        opts = ["--error-format=raw", "--no-progress"]
+
+        if settings.get("use_composer_autoload", True):
+            autoload_file = self.find_autoload_php(self.view.file_name())
+            if autoload_file:
+                opts.append("--autoload-file={}".format(quote(autoload_file)))
+
+        return cmd + opts + ["${args}", "--", "${file}"]
+
+    def find_autoload_php(self, file_path):
+        basedir = None
+        while file_path:
+            basedir = path.dirname(file_path)
+            composer_json = "{basedir}/composer.json".format(basedir=basedir)
+            composer_lock = "{basedir}/composer.lock".format(basedir=basedir)
+            autoload = "{basedir}/vendor/autoload.php".format(basedir=basedir)
+            if path.isfile(autoload) and (
+                path.isfile(composer_json) or path.isfile(composer_lock)
+            ):
+                return autoload
+            if basedir == file_path:
+                break
+            file_path = basedir


### PR DESCRIPTION
Hi,

this fixes issue #5 and issue #1.
If you still need to autoload the file being linted itself, turn of "use_composer_autoload" and load the file using linter args:

        "SublimeLinter.linters.phpstan.args": "--autoload-file=${file}",
        "SublimeLinter.linters.phpstan.use_composer_autoload": false

Otherwise this will search for an autoloader from composer and only call phpstan with `--autoload-file` if it found one.
No PHP code will be executed except the autoloader.