### PR TITLE
feat: Better method of re-linting on activation (after changes), closes #22

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -8,7 +8,7 @@ import re
 import sublime
 import sublime_plugin
 
-from SublimeLinter import lint
+from SublimeLinter.lint import LintMatch, PhpLinter
 from SublimeLinter.lint.quick_fix import (QuickAction, extend_existing_comment, insert_preceding_line, line_error_is_on, merge_actions_by_code_and_line, quick_actions_for, read_previous_line)
 
 logger = logging.getLogger("SublimeLinter.plugins.phpstan")
@@ -28,7 +28,7 @@ class AutoLintOnTabSwitchListener(sublime_plugin.ViewEventListener):
         if self.view.file_name() and self.view.file_name().endswith(".php"):
             self.view.run_command("sublime_linter_lint")
 
-class PhpStan(lint.PhpLinter):
+class PhpStan(PhpLinter):
     tempfile_suffix = "-"
 
     defaults = {
@@ -188,7 +188,7 @@ class PhpStan(lint.PhpLinter):
                         col = pos[0]
                         end_col = pos[1]
 
-                match = lint.LintMatch(
+                match = LintMatch(
                     match=error,
                     filename=file,
                     line=error['line'] - 1,

--- a/linter.py
+++ b/linter.py
@@ -15,8 +15,7 @@ class AutoLintOnTabSwitchListener(sublime_plugin.ViewEventListener):
     @classmethod
     def is_applicable(cls, settings):
         try:
-            user_settings = sublime.load_settings('SublimeLinter.sublime-settings')
-            auto_lint_setting = settings.get('SublimeLinter.linters.phpstan.auto_lint_on_tab_switch') or user_settings.get('linters')['phpstan']['auto_lint_on_tab_switch']
+            auto_lint_setting = lint.persist.settings.get('linters')['phpstan']['auto_lint_on_tab_switch']
             auto_lint = bool(auto_lint_setting)
         except KeyError:
             auto_lint = False

--- a/linter.py
+++ b/linter.py
@@ -39,7 +39,7 @@ class PhpStan(PhpLinter):
     stderr_strip_regexes = [
         # This is necessary because phpstan may be passed the `-v` argument, which also causes it to output some stats on stderr
         # Rather than always requiring phpstan to run non-verbosely (which isn't very friendly), we'll simply try to strip the relevant lines
-        re.compile(r'^Elapsed time: .*?(\r?\nUsed memory: .*)?$', re.MULTILINE),
+        re.compile(r'^(Elapsed time|Used memory): .+', re.MULTILINE),
     ]
 
     # If the remainder of stderr matches one of these strings entirely, we'll change it to a warning instead of an error

--- a/linter.py
+++ b/linter.py
@@ -3,6 +3,8 @@ from shlex import quote
 import logging
 import json
 import re
+
+import sublime
 import sublime_plugin
 
 from SublimeLinter import lint
@@ -12,7 +14,14 @@ logger = logging.getLogger("SublimeLinter.plugins.phpstan")
 class AutoLintOnTabSwitchListener(sublime_plugin.ViewEventListener):
     @classmethod
     def is_applicable(cls, settings):
-        return True
+        try:
+            user_settings = sublime.load_settings('SublimeLinter.sublime-settings')
+            auto_lint_setting = settings.get('SublimeLinter.linters.phpstan.auto_lint_on_tab_switch') or user_settings.get('linters')['phpstan']['auto_lint_on_tab_switch']
+            auto_lint = bool(auto_lint_setting)
+        except KeyError:
+            auto_lint = False
+
+        return auto_lint
 
     def on_activated_async(self):
         if self.view.file_name() and self.view.file_name().endswith(".php"):


### PR DESCRIPTION
It is a bit hacky but I couldn't figure out a better way unfortunately. The actual developer documentation from SublimeLinter is quite sparse.