### PR TITLE
use PhpLinter

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ class AutoLintOnTabSwitchListener(sublime_plugin.ViewEventListener):
         if self.view.file_name() and self.view.file_name().endswith(".php"):
             self.view.run_command("sublime_linter_lint")
 
-class PhpStan(lint.Linter):
+class PhpStan(lint.PhpLinter):
     tempfile_suffix = "-"
 
     defaults = {


### PR DESCRIPTION
so that it knows how to find the exe in vendor/bin, and supports [disable_if_not_dependency](https://github.com/SublimeLinter/SublimeLinter/commit/3a2e07eaa87e3f9a21549e99c699226c717bbda7)